### PR TITLE
feat: [AF-02] - Allow to define extra env vars

### DIFF
--- a/charts/lightdash/templates/deployment.yaml
+++ b/charts/lightdash/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
             - secretRef:
                 name: {{ template "helm.fullname" $ }}
           {{- end }}
+          env:
+          {{- if .Values.extraEnvVars }}
+            {{- .Values.extraEnvVars | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
This PR aims to allow to define extra env vars, so we can pass extra secrets as in the env vars.

```
  - name: POSTGRES_PASSWORD
    valueFrom:
      secretKeyRef:
        name: {{ .Values.postgresql.existingSecret }}
        key: {{ .Values.postgresql.existingSecretKey }}
```